### PR TITLE
Fix/score column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.1.1 - 2025-07-22](#111---2025-07-22)
 - [1.1.0 - 2025-07-18](#110---2025-07-18)
 - [1.0.0 - YYYY-MM-DD](#100---yyyy-mm-dd)
 
@@ -27,6 +28,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Security
 - (Notify of any improvements related to security vulnerabilities or potential risks.)
+
+---
+
+## [1.1.1] - 2025-07-22
+
+### Changed
+
+- score column type changed from float to bigint to handle large timestamp values
 
 ---
 

--- a/src/storage/knex/all-migrations.ts
+++ b/src/storage/knex/all-migrations.ts
@@ -5,6 +5,7 @@ import { up as addTransactionsTableUp, down as addTransactionsTableDown } from '
 import { up as addedIndexesUp, down as addedIndexesDown } from './migrations/2024-07-18-001-indexes.js'
 import { up as enlargeUp, down as enlargeDown } from './migrations/2025-05-28-001-enlarge.js'
 import { up as gaspPaginationSupportUp, down as gaspPaginationSupportDown } from './migrations/2025-06-25-001-gasp-pagination-support.js'
+import { up as fixScoreColumnTypeUp, down as fixScoreColumnTypeDown } from './migrations/2025-07-22-001-fix-score-column-type.js'
 
 
 
@@ -22,7 +23,8 @@ const allMigrations: Migration[] = [
   { up: addTransactionsTableUp, down: addTransactionsTableDown },
   { up: addedIndexesUp, down: addedIndexesDown },
   { up: enlargeUp, down: enlargeDown },
-  { up: gaspPaginationSupportUp, down: gaspPaginationSupportDown }
+  { up: gaspPaginationSupportUp, down: gaspPaginationSupportDown },
+  { up: fixScoreColumnTypeUp, down: fixScoreColumnTypeDown }
 ]
 
 export default allMigrations

--- a/src/storage/knex/migrations/2025-07-22-001-fix-score-column-type.ts
+++ b/src/storage/knex/migrations/2025-07-22-001-fix-score-column-type.ts
@@ -1,0 +1,24 @@
+import type { Knex } from 'knex'
+
+export async function up (knex: Knex): Promise<void> {
+  // Fix score column type from float to bigint to handle large timestamp values
+  const hasScoreColumn = await knex.schema.hasColumn('outputs', 'score')
+  
+  if (hasScoreColumn) {
+    // Modify the score column to be bigint instead of float
+    await knex.schema.table('outputs', table => {
+      table.bigInteger('score').notNullable().defaultTo(0).alter()
+    })
+  }
+}
+
+export async function down (knex: Knex): Promise<void> {
+  // Rollback to original float type
+  const hasScoreColumn = await knex.schema.hasColumn('outputs', 'score')
+  
+  if (hasScoreColumn) {
+    await knex.schema.table('outputs', table => {
+      table.float('score').notNullable().defaultTo(0).alter()
+    })
+  }
+}


### PR DESCRIPTION
# Summary
I've successfully fixed the SQL error by creating a new migration to address the root cause:

## The Problem
The SQL error "Out of range value for column 'score' at row 1" occurred because:

The score column in the outputs table was defined as float(8,2) (max value: 999,999.99)
The application was trying to insert large timestamp values like 1753154802300
This value exceeded the column's capacity

## The Solution
Created Migration: 
2025-07-22-001-fix-score-column-type.ts
 that changes the score column from float(8,2) to bigint

Updated All Migrations: Added the new migration to 
all-migrations.ts
 to ensure it runs in the proper sequence

Migration Details
Up: Changes score column to bigint to handle large timestamp values
Down: Rollback option to revert to original float type if needed
Safe: Includes proper column existence checks before making changes

The migration will automatically run when the overlay services are next deployed or when migrations are manually executed, permanently fixing this database schema issue.