### PR TITLE
Ship slap suppressor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [0.4.5 - 2025-07-24](#111---2025-07-24)
 - [0.4.4 - 2025-07-22](#111---2025-07-22)
 - [0.4.3 - 2025-07-18](#110---2025-07-18)
 - [0.0.1 - YYYY-MM-DD](#100---yyyy-mm-dd)
@@ -28,6 +29,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Security
 - (Notify of any improvements related to security vulnerabilities or potential risks.)
+
+---
+
+### Added
+- Support suppressing ship/slap advertisements.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/overlay",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/overlay",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/gasp": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/gasp": "^1.2.0",
-        "@bsv/sdk": "^1.6.16",
+        "@bsv/sdk": "^1.6.20",
         "knex": "^3.1.0"
       },
       "devDependencies": {
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.6.16.tgz",
-      "integrity": "sha512-uDYYFeN9gJmj/Mb8DEaeGJ4lY4WLRer1sDAItIDRZMeTdA+aIQbxd7nKteFlC05siXYmoQHQV8qvTTxEx75aXg==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.6.20.tgz",
+      "integrity": "sha512-EiUKTzIlBqYRW135skDtMV0i99D5VhiNPxWzP+F0WpwzuTdDx4jWrOfxLtsfgq8Rp8dQdk9ouqpavBUSSbhdRQ==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@bsv/gasp": "^1.2.0",
-    "@bsv/sdk": "^1.6.16",
+    "@bsv/sdk": "^1.6.20",
     "knex": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/overlay",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "description": "BSV Blockchain Overlay Services Engine",
   "main": "dist/cjs/mod.js",


### PR DESCRIPTION
## Description of Changes

- Added support for suppressing ship/slap advertisements. Not every overlay service needs to public advertise the ability to sync ship/slap advertisements, so this will suppress by default.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged