### PR TITLE
Include beef with output to fix 'not found' error

### DIFF
--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -765,7 +765,7 @@ export class Engine {
     }
 
     const [rootTxid, rootOutputIndex] = graphID.split('.')
-    const output = await this.storage.findOutput(rootTxid, Number(rootOutputIndex))
+    const output = await this.storage.findOutput(rootTxid, Number(rootOutputIndex), undefined, undefined, true)
     return await hydrator(output)
   }
 


### PR DESCRIPTION
## Description of Changes

The `provideForeignGASPNode` function checks (in `hydrator`) for BEEF in output and if it does not find it then it returns "No matching output found" error. When querying for output it is not setting the `includeBEEF` field which defaults to false. All calls to this function seem to be failing.

Internally you get this error:

```
❌ Error in /requestForeignGASPNode: Error: No matching output found!
    at hydrator (/src/express-overlay-example/node_modules/@bsv/overlay/src/Engine.ts:712:15)
    at Engine.provideForeignGASPNode (/src/express-overlay-example/node_modules/@bsv/overlay/src/Engine.ts:769:18)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async <anonymous> (/src/express-overlay-example/node_modules/@bsv/overlay-express/src/OverlayExpress.ts:802:30)
📤 Outgoing Response: POST /requestForeignGASPNode - Status: 400 - Duration: 3ms
```

Externally when doing GASP sync you get a 400 error and this message:

```
{"status":"error","message":"No matching output found!"}
```

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged